### PR TITLE
Revert "chore(main): release 1.0.0 (#2)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Changelog
-
-## 1.0.0 (2022-07-04)
-
-
-### Features
-
-* Initial import of project files ([#1](https://github.com/meyfa/eslint-config/issues/1)) ([b252f2c](https://github.com/meyfa/eslint-config/commit/b252f2c45b929ed5f113c9586de0542e5ac462ee))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meyfa/eslint-config",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@meyfa/eslint-config",
-      "version": "1.0.0",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@rushstack/eslint-patch": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meyfa/eslint-config",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "ESLint config for personal TypeScript projects.",
   "type": "commonjs",
   "main": "dist/index.js",


### PR DESCRIPTION
This reverts commit 0a6f2a6062603bf843411639ed9d500516828363.

Reason: Publishing to NPM failed due to missing `--access public` CLI flag in the release-please workflow. We'll have to try this again!