### PR TITLE
feat!: Raise Node.js version requirement, drop support for v16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm publish --provenance --access public

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "typescript": "5.5.3"
       },
       "engines": {
-        "node": ">=16"
+        "node": "^18.18.0 || ^20.9.0 || >=22"
       },
       "peerDependencies": {
         "eslint": "^8.57.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=16"
+    "node": "^18.18.0 || ^20.9.0 || >=22"
   },
   "scripts": {
     "build": "node -e \"fs.rmSync('./dist',{force:true,recursive:true})\" && tsc",


### PR DESCRIPTION
The new version range matches that of ESLint v9. While the current config is not yet based on ESLint v9, it still makes sense to remove EOL Node.js v16 from the supported versions at this point.