### PR TITLE
chore: Use build output for linting this project itself

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,22 +1,3 @@
-extends: 'standard'
-plugins:
-  - unicorn
-rules:
-  'import/extensions': ['error', 'always', { ignorePackages: true }]
-  'unicorn/prefer-node-protocol': 'error'
-  'unicorn/custom-error-definition': 'error'
-  'unicorn/no-instanceof-array': 'error'
-  'unicorn/no-typeof-undefined': 'error'
-  'unicorn/no-useless-fallback-in-spread': 'error'
-  'unicorn/prefer-at': 'error'
-  'unicorn/prefer-date-now': 'error'
-  'unicorn/prefer-number-properties': ['error', { checkInfinity: false }]
-  'unicorn/prefer-string-slice': 'error'
-  'unicorn/require-array-join-separator': 'error'
-  'unicorn/throw-new-error': 'error'
-  radix: 'error'
-overrides:
-  - files: ['*.ts', '*.tsx']
-    extends: 'standard-with-typescript'
+extends: './dist/index.js'
 parserOptions:
   project: './tsconfig.json'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,4 +17,5 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - run: npm run build
       - run: npm run lint


### PR DESCRIPTION
Instead of duplicating this config in `.eslintrc.yml`, we now build it, and use the actual config to lint itself.