### PR TITLE
feat!: Vendor base config and update TypeScript ESLint plugin to v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,3 @@ overrides:
   - files: ['src/**/*.ts']
     extends: '@meyfa/eslint-config/jsdoc'
 ```
-
-## Rules
-
-This package provides all the rules from [eslint-config-standard-with-typescript](https://github.com/standard/eslint-config-standard-with-typescript/)
-with a few changes.
-For example, it customizes some things for files that match the glob `test/**/*` to work better with Mocha/Chai,
-and disables some impractical defaults.
-
-The main reason this package exists is to avoid having to install all peer dependencies of
-eslint-config-standard-with-typescript.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@rushstack/eslint-patch": "1.10.3",
-        "@typescript-eslint/eslint-plugin": "6.21.0",
+        "@typescript-eslint/eslint-plugin": "7.17.0",
         "eslint-config-standard": "17.1.0",
-        "eslint-config-standard-with-typescript": "38.0.0",
         "eslint-plugin-import": "2.29.1",
         "eslint-plugin-jsdoc": "48.8.3",
         "eslint-plugin-n": "16.6.2",
@@ -20,6 +19,7 @@
         "eslint-plugin-unicorn": "55.0.0"
       },
       "devDependencies": {
+        "@types/eslint": "8.56.11",
         "@types/node": "20.14.12",
         "eslint": "8.57.0",
         "typescript": "5.5.3"
@@ -314,10 +314,27 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.3.tgz",
       "integrity": "sha512-qC/xYId4NMebE6w/V33Fh9gWxLgURiNYgVNObbJl2LZv0GUUItCcCqC5axQSwRaAgaxl2mELq1rMzlswaQ0Zxg=="
     },
+    "node_modules/@types/eslint": {
+      "version": "8.56.11",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.11.tgz",
+      "integrity": "sha512-sVBpJMf7UPo/wGecYOpk2aQya2VUGeHhe38WG7/mN5FufNSubf5VT9Uh9Uyp8/eLJpu1/tuhJ/qTo4mhSB4V4Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -338,38 +355,31 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
     },
-    "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ=="
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.17.0.tgz",
+      "integrity": "sha512-pyiDhEuLM3PuANxH7uNYan1AaFs5XE0zw1hq69JBvGvE7gSuEoQl1ydtEe/XQeoC3GQxLXyOVa5kNOATgM638A==",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/type-utils": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4",
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.17.0",
+        "@typescript-eslint/type-utils": "7.17.0",
+        "@typescript-eslint/utils": "7.17.0",
+        "@typescript-eslint/visitor-keys": "7.17.0",
         "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
+        "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-        "eslint": "^7.0.0 || ^8.0.0"
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -378,25 +388,26 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.17.0.tgz",
+      "integrity": "sha512-puiYfGeg5Ydop8eusb/Hy1k7QmOU6X3nvsqCgzrB2K4qMavK//21+PzNE8qeECgNOIoertJPUC1SpegHDI515A==",
+      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/scope-manager": "7.17.0",
+        "@typescript-eslint/types": "7.17.0",
+        "@typescript-eslint/typescript-estree": "7.17.0",
+        "@typescript-eslint/visitor-keys": "7.17.0",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -405,15 +416,15 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.17.0.tgz",
+      "integrity": "sha512-0P2jTTqyxWp9HiKLu/Vemr2Rg1Xb5B7uHItdVZ6iAenXmPo4SZ86yOPCJwMqpCyaMiEHTNqizHfsbmCFT1x9SA==",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0"
+        "@typescript-eslint/types": "7.17.0",
+        "@typescript-eslint/visitor-keys": "7.17.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -421,24 +432,24 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.17.0.tgz",
+      "integrity": "sha512-XD3aaBt+orgkM/7Cei0XNEm1vwUxQ958AOLALzPlbPqb8C1G8PZK85tND7Jpe69Wualri81PLU+Zc48GVKIMMA==",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
+        "@typescript-eslint/typescript-estree": "7.17.0",
+        "@typescript-eslint/utils": "7.17.0",
         "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -447,11 +458,11 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-a29Ir0EbyKTKHnZWbNsrc/gqfIBqYPwj3F2M+jWE/9bqfEHg0AMtXzkbUkOG6QgEScxh2+Pz9OXe11jHDnHR7A==",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -459,21 +470,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.17.0.tgz",
+      "integrity": "sha512-72I3TGq93t2GoSBWI093wmKo0n6/b7O4j9o8U+f65TVD0FS6bI2180X5eGEr8MA8PhKMvYe9myZJquUT2JkCZw==",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/types": "7.17.0",
+        "@typescript-eslint/visitor-keys": "7.17.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -486,39 +497,36 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.17.0.tgz",
+      "integrity": "sha512-r+JFlm5NdB+JXc7aWWZ3fKSm1gn0pkswEwIYsrGPdsT2GjsRATAKXiNtp3vgAAO1xZhX8alIOEQnNMl3kbTgJw==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "semver": "^7.5.4"
+        "@typescript-eslint/scope-manager": "7.17.0",
+        "@typescript-eslint/types": "7.17.0",
+        "@typescript-eslint/typescript-estree": "7.17.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.17.0.tgz",
+      "integrity": "sha512-RVGC9UhPOCsfCdI9pU++K4nD7to+jTcMIbXTSOcrLqUEW6gF2pU1UUbYJKc9cvcRSK1UDeMJ7pdMxf4bhMpV/A==",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "@typescript-eslint/types": "7.17.0",
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1330,24 +1338,6 @@
         "eslint-plugin-import": "^2.25.2",
         "eslint-plugin-n": "^15.0.0 || ^16.0.0 ",
         "eslint-plugin-promise": "^6.0.0"
-      }
-    },
-    "node_modules/eslint-config-standard-with-typescript": {
-      "version": "38.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-38.0.0.tgz",
-      "integrity": "sha512-G7JR6I8tmWEQjzbESo/9gVq4AQctbVO4J8PINQj8l2lgbJF/W9KCJ4uDLiKmLMjWszW/F5SsucoA/5VpHvfwOQ==",
-      "deprecated": "Please use eslint-config-love, instead.",
-      "dependencies": {
-        "@typescript-eslint/parser": "^6.1.0",
-        "eslint-config-standard": "17.1.0"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^6.1.0",
-        "eslint": "^8.0.1",
-        "eslint-plugin-import": "^2.25.2",
-        "eslint-plugin-n": "^15.0.0 || ^16.0.0 ",
-        "eslint-plugin-promise": "^6.0.0",
-        "typescript": "*"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -2576,9 +2566,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -43,9 +43,8 @@
   },
   "dependencies": {
     "@rushstack/eslint-patch": "1.10.3",
-    "@typescript-eslint/eslint-plugin": "6.21.0",
+    "@typescript-eslint/eslint-plugin": "7.17.0",
     "eslint-config-standard": "17.1.0",
-    "eslint-config-standard-with-typescript": "38.0.0",
     "eslint-plugin-import": "2.29.1",
     "eslint-plugin-jsdoc": "48.8.3",
     "eslint-plugin-n": "16.6.2",
@@ -53,6 +52,7 @@
     "eslint-plugin-unicorn": "55.0.0"
   },
   "devDependencies": {
+    "@types/eslint": "8.56.11",
     "@types/node": "20.14.12",
     "eslint": "8.57.0",
     "typescript": "5.5.3"

--- a/src/eslint-config-standard-with-typescript.ts
+++ b/src/eslint-config-standard-with-typescript.ts
@@ -1,0 +1,236 @@
+/**
+ * Adapted from eslint-config-standard-with-typescript v40.0.0, with some v44.0.0 sprinkled in.
+ *
+ * eslint-config-standard-with-typescript is now called eslint-config-love, and is maintained by Shahar "Dawn" Or.
+ * It is licensed under the MIT license. See: https://github.com/mightyiam/eslint-config-love/blob/main/LICENSE
+ */
+
+import type { Linter } from 'eslint'
+import configStandard = require('./eslint-config-standard.js')
+
+const equivalents = [
+  'block-spacing',
+  'comma-spacing',
+  'dot-notation',
+  'brace-style',
+  'func-call-spacing',
+  'indent',
+  'key-spacing',
+  'keyword-spacing',
+  'lines-between-class-members',
+  'no-array-constructor',
+  'no-dupe-class-members',
+  'no-extra-parens',
+  'no-implied-eval',
+  'no-loss-of-precision',
+  'no-redeclare',
+  'no-throw-literal',
+  'no-unused-vars',
+  'no-unused-expressions',
+  'no-useless-constructor',
+  'object-curly-spacing',
+  'prefer-promise-reject-errors',
+  'quotes',
+  'semi',
+  'space-before-blocks',
+  'space-before-function-paren',
+  'space-infix-ops'
+] as const
+
+const ruleFromStandard = (name: string): Linter.RuleEntry => {
+  if (configStandard.rules === undefined) throw new Error()
+  const rule = configStandard.rules[name]
+  if (rule === undefined) throw new Error()
+  if (typeof rule !== 'object') return rule
+  return JSON.parse(JSON.stringify(rule))
+}
+
+function fromEntries<T> (iterable: Array<[string, T]>): Record<string, T> {
+  return [...iterable].reduce<Record<string, T>>((obj, [key, val]) => {
+    obj[key] = val
+    return obj
+  }, {})
+}
+
+const config: Linter.Config = {
+  extends: 'eslint-config-standard',
+  plugins: ['@typescript-eslint'],
+  parser: '@typescript-eslint/parser',
+  rules: {
+    'comma-dangle': 'off',
+
+    // TypeScript has this functionality by default:
+    'no-undef': 'off',
+
+    // Rules replaced by @typescript-eslint versions:
+    ...fromEntries(equivalents.map((name) => [name, 'off'])),
+    camelcase: 'off',
+    'no-use-before-define': 'off',
+
+    // @typescript-eslint versions of Standard.js rules:
+    ...fromEntries(equivalents.map((name) => [`@typescript-eslint/${name}`, ruleFromStandard(name)])),
+    '@typescript-eslint/no-use-before-define': ['error', {
+      functions: false,
+      classes: false,
+      enums: false,
+      variables: false,
+      typedefs: false // Only the TypeScript rule has this option.
+    }],
+
+    // Rules exclusive to Standard TypeScript:
+    '@typescript-eslint/adjacent-overload-signatures': 'error',
+    '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
+    '@typescript-eslint/await-thenable': 'error',
+    '@typescript-eslint/ban-ts-comment': ['error', {
+      'ts-expect-error': 'allow-with-description',
+      'ts-ignore': true,
+      'ts-nocheck': true,
+      'ts-check': false,
+      minimumDescriptionLength: 3
+    }],
+    '@typescript-eslint/ban-tslint-comment': 'error',
+    '@typescript-eslint/ban-types': ['error', {
+      extendDefaults: false,
+      types: {
+        String: {
+          message: 'Use string instead',
+          fixWith: 'string'
+        },
+        Boolean: {
+          message: 'Use boolean instead',
+          fixWith: 'boolean'
+        },
+        Number: {
+          message: 'Use number instead',
+          fixWith: 'number'
+        },
+        Symbol: {
+          message: 'Use symbol instead',
+          fixWith: 'symbol'
+        },
+        BigInt: {
+          message: 'Use bigint instead',
+          fixWith: 'bigint'
+        },
+        Function: {
+          message: [
+            'The `Function` type accepts any function-like value.',
+            'It provides no type safety when calling the function, which can be a common source of bugs.',
+            'It also accepts things like class declarations, which will throw at runtime as they will not be called with `new`.',
+            'If you are expecting the function to accept certain arguments, you should explicitly define the function shape.'
+          ].join('\n')
+        },
+        // object typing
+        Object: {
+          message: [
+            'The `Object` type actually means "any non-nullish value", so it is marginally better than `unknown`.',
+            '- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.',
+            '- If you want a type meaning "any value", you probably want `unknown` instead.'
+          ].join('\n')
+        },
+        '{}': {
+          message: [
+            '`{}` actually means "any non-nullish value".',
+            '- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.',
+            '- If you want a type meaning "any value", you probably want `unknown` instead.'
+          ].join('\n')
+        }
+      }
+    }],
+    '@typescript-eslint/class-literal-property-style': ['error', 'fields'],
+    '@typescript-eslint/comma-dangle': ['error', {
+      arrays: 'never',
+      objects: 'never',
+      imports: 'never',
+      exports: 'never',
+      functions: 'never',
+      enums: 'ignore',
+      generics: 'ignore',
+      tuples: 'ignore'
+    }],
+    '@typescript-eslint/consistent-generic-constructors': ['error', 'constructor'],
+    '@typescript-eslint/consistent-indexed-object-style': ['error', 'record'],
+    '@typescript-eslint/consistent-type-assertions': [
+      'error',
+      {
+        assertionStyle: 'as',
+        objectLiteralTypeAssertions: 'never'
+      }
+    ],
+    '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
+    '@typescript-eslint/consistent-type-exports': ['error', {
+      fixMixedExportsWithInlineTypeSpecifier: true
+    }],
+    '@typescript-eslint/consistent-type-imports': ['error', {
+      prefer: 'type-imports',
+      disallowTypeAnnotations: true,
+      fixStyle: 'inline-type-imports'
+    }],
+    '@typescript-eslint/explicit-function-return-type': ['error', {
+      allowExpressions: true,
+      allowHigherOrderFunctions: true,
+      allowTypedFunctionExpressions: true,
+      allowDirectConstAssertionInArrowFunctions: true
+    }],
+    '@typescript-eslint/member-delimiter-style': [
+      'error',
+      {
+        multiline: { delimiter: 'none' },
+        singleline: { delimiter: 'comma', requireLast: false }
+      }
+    ],
+    '@typescript-eslint/method-signature-style': 'error',
+    '@typescript-eslint/naming-convention': ['error', {
+      selector: 'variableLike',
+      leadingUnderscore: 'allow',
+      trailingUnderscore: 'allow',
+      format: ['camelCase', 'PascalCase', 'UPPER_CASE']
+    }],
+    '@typescript-eslint/no-base-to-string': 'error',
+    '@typescript-eslint/no-confusing-void-expression': ['error', { ignoreArrowShorthand: false, ignoreVoidOperator: false }],
+    '@typescript-eslint/no-dynamic-delete': 'error',
+    '@typescript-eslint/no-empty-interface': ['error', { allowSingleExtends: true }],
+    '@typescript-eslint/no-extra-non-null-assertion': 'error',
+    '@typescript-eslint/no-extraneous-class': ['error', { allowWithDecorator: true }],
+    '@typescript-eslint/no-floating-promises': 'error',
+    '@typescript-eslint/no-for-in-array': 'error',
+    '@typescript-eslint/no-invalid-void-type': 'error',
+    '@typescript-eslint/no-misused-new': 'error',
+    '@typescript-eslint/no-misused-promises': 'error',
+    '@typescript-eslint/no-namespace': 'error',
+    '@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
+    '@typescript-eslint/no-non-null-assertion': 'error',
+    '@typescript-eslint/no-this-alias': ['error', { allowDestructuring: true }],
+    '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
+    '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+    '@typescript-eslint/no-unnecessary-type-constraint': 'error',
+    '@typescript-eslint/no-var-requires': 'error',
+    '@typescript-eslint/prefer-function-type': 'error',
+    '@typescript-eslint/prefer-includes': 'error',
+    '@typescript-eslint/prefer-nullish-coalescing': ['error', { ignoreConditionalTests: false, ignoreMixedLogicalExpressions: false }],
+    '@typescript-eslint/prefer-optional-chain': 'error',
+    '@typescript-eslint/prefer-readonly': 'error',
+    '@typescript-eslint/prefer-reduce-type-parameter': 'error',
+    '@typescript-eslint/prefer-ts-expect-error': 'error',
+    '@typescript-eslint/promise-function-async': 'error',
+    '@typescript-eslint/require-array-sort-compare': ['error', { ignoreStringArrays: true }],
+    '@typescript-eslint/restrict-plus-operands': ['error', { skipCompoundAssignments: false }],
+    '@typescript-eslint/restrict-template-expressions': ['error', { allowNumber: true }],
+    '@typescript-eslint/return-await': ['error', 'always'],
+    '@typescript-eslint/strict-boolean-expressions': ['error', {
+      allowString: false,
+      allowNumber: false,
+      allowNullableObject: false,
+      allowNullableBoolean: false,
+      allowNullableString: false,
+      allowNullableNumber: false,
+      allowAny: false
+    }],
+    '@typescript-eslint/triple-slash-reference': ['error', { lib: 'never', path: 'never', types: 'never' }],
+    '@typescript-eslint/type-annotation-spacing': 'error',
+    '@typescript-eslint/unbound-method': ['error', { ignoreStatic: false }],
+    'no-void': ['error', { allowAsStatement: true }]
+  }
+}
+
+export = config

--- a/src/eslint-config-standard.ts
+++ b/src/eslint-config-standard.ts
@@ -1,0 +1,6 @@
+import type { Linter } from 'eslint'
+
+import config = require('eslint-config-standard')
+
+const casted = config as Linter.Config
+export = casted

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
+/* eslint-disable import/first */
+
 // ESLint patching to support proper plugin resolution
 require('@rushstack/eslint-patch/modern-module-resolution.js')
+
+import swt = require('./eslint-config-standard-with-typescript.js')
 
 export = {
   extends: 'standard',
@@ -39,8 +43,10 @@ export = {
   overrides: [
     {
       files: ['*.ts', '*.tsx'],
-      extends: 'standard-with-typescript',
+      plugins: swt.plugins,
+      parser: swt.parser,
       rules: {
+        ...swt.rules,
         // This is active in standard-with-typescript, but would be a huge migration task at this time.
         '@typescript-eslint/consistent-type-imports': 'off',
         // standard-with-typescript enforces no-confusing-void-expression even for the arrow shorthand.

--- a/src/standard.d.ts
+++ b/src/standard.d.ts
@@ -1,0 +1,1 @@
+declare module 'eslint-config-standard'


### PR DESCRIPTION
The governance of eslint-config-standard and -with-typescript is unclear and causing trouble for this project. This patch pulls in the relevant code from -with-standard as a first step towards fully owning the ESLint configuration. A follow-up patch is planned to do the same for eslint-config-standard.

By doing this, we are able to upgrade `@typescript-eslint/eslint-plugin` from v6 to v7, which is the current latest version.

Refs: https://github.com/standard/standard/issues/1948
Refs: https://github.com/standard/standard/issues/1957