### PR TITLE
feat!: Use stylistic rules from eslint-stylistic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@rushstack/eslint-patch": "1.10.4",
+        "@stylistic/eslint-plugin": "2.6.1",
         "@typescript-eslint/eslint-plugin": "7.18.0",
         "eslint-plugin-import": "2.29.1",
         "eslint-plugin-jsdoc": "48.11.0",
@@ -314,6 +315,353 @@
       "integrity": "sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==",
       "license": "MIT"
     },
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.6.1.tgz",
+      "integrity": "sha512-UT0f4t+3sQ/GKW7875NiIIjZJ1Bh4gd7JNfoIkwIQyWqO7wGd0Pqzu0Ho30Ka8MNF5lm++SkVeqAk26vGxoUpg==",
+      "dependencies": {
+        "@stylistic/eslint-plugin-js": "2.6.1",
+        "@stylistic/eslint-plugin-jsx": "2.6.1",
+        "@stylistic/eslint-plugin-plus": "2.6.1",
+        "@stylistic/eslint-plugin-ts": "2.6.1",
+        "@types/eslint": "^9.6.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.6.1.tgz",
+      "integrity": "sha512-iLOiVzcvqzDGD9U0EuVOX680v+XOPiPAjkxWj+Q6iV2GLOM5NB27tKVOpJY7AzBhidwpRbaLTgg3T4UzYx09jw==",
+      "dependencies": {
+        "@types/eslint": "^9.6.0",
+        "acorn": "^8.12.1",
+        "eslint-visitor-keys": "^4.0.0",
+        "espree": "^10.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js/node_modules/@types/eslint": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
+      "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js/node_modules/eslint-visitor-keys": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js/node_modules/espree": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
+      "integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
+      "dependencies": {
+        "acorn": "^8.12.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-jsx": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-2.6.1.tgz",
+      "integrity": "sha512-5qHLXqxfY6jubAQfDqrifv41fx7gaqA9svDaChxMI6JiHpEBfh+PXxmm3g+B8gJCYVBTC62Rjl0Ny5QabK58bw==",
+      "dependencies": {
+        "@stylistic/eslint-plugin-js": "^2.6.1",
+        "@types/eslint": "^9.6.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-jsx/node_modules/@types/eslint": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
+      "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-jsx/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-2.6.1.tgz",
+      "integrity": "sha512-z/IYu/q8ipApzNam5utSU+BrXg4pK/Gv9xNbr4eWv/bZppvTWJU62xCO4nw/6r2dHNPnqc7uCHEC7GMlBnPY0A==",
+      "dependencies": {
+        "@types/eslint": "^9.6.0",
+        "@typescript-eslint/utils": "^8.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@types/eslint": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
+      "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.0.0.tgz",
+      "integrity": "sha512-V0aa9Csx/ZWWv2IPgTfY7T4agYwJyILESu/PVqFtTFz9RIS823mAze+NbnBI8xiwdX3iqeQbcTYlvB04G9wyQw==",
+      "dependencies": {
+        "@typescript-eslint/types": "8.0.0",
+        "@typescript-eslint/visitor-keys": "8.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/types": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.0.0.tgz",
+      "integrity": "sha512-wgdSGs9BTMWQ7ooeHtu5quddKKs5Z5dS+fHLbrQI+ID0XWJLODGMHRfhwImiHoeO2S5Wir2yXuadJN6/l4JRxw==",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.0.0.tgz",
+      "integrity": "sha512-5b97WpKMX+Y43YKi4zVcCVLtK5F98dFls3Oxui8LbnmRsseKenbbDinmvxrWegKDMmlkIq/XHuyy0UGLtpCDKg==",
+      "dependencies": {
+        "@typescript-eslint/types": "8.0.0",
+        "@typescript-eslint/visitor-keys": "8.0.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/utils": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.0.0.tgz",
+      "integrity": "sha512-k/oS/A/3QeGLRvOWCg6/9rATJL5rec7/5s1YmdS0ZU6LHveJyGFwBvLhSRBv6i9xaj7etmosp+l+ViN1I9Aj/Q==",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.0.0",
+        "@typescript-eslint/types": "8.0.0",
+        "@typescript-eslint/typescript-estree": "8.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.0.0.tgz",
+      "integrity": "sha512-oN0K4nkHuOyF3PVMyETbpP5zp6wfyOvm7tWhTMfoqxSSsPmJIh6JNASuZDlODE8eE+0EB9uar+6+vxr9DBTYOA==",
+      "dependencies": {
+        "@typescript-eslint/types": "8.0.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-2.6.1.tgz",
+      "integrity": "sha512-Mxl1VMorEG1Hc6oBYPD0+KIJOWkjEF1R0liL7wWgKfwpqOkgmnh5lVdZBrYyfRKOE4RlGcwEFTNai1IW6orgVg==",
+      "dependencies": {
+        "@stylistic/eslint-plugin-js": "2.6.1",
+        "@types/eslint": "^9.6.0",
+        "@typescript-eslint/utils": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@types/eslint": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
+      "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.0.0.tgz",
+      "integrity": "sha512-V0aa9Csx/ZWWv2IPgTfY7T4agYwJyILESu/PVqFtTFz9RIS823mAze+NbnBI8xiwdX3iqeQbcTYlvB04G9wyQw==",
+      "dependencies": {
+        "@typescript-eslint/types": "8.0.0",
+        "@typescript-eslint/visitor-keys": "8.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/types": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.0.0.tgz",
+      "integrity": "sha512-wgdSGs9BTMWQ7ooeHtu5quddKKs5Z5dS+fHLbrQI+ID0XWJLODGMHRfhwImiHoeO2S5Wir2yXuadJN6/l4JRxw==",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.0.0.tgz",
+      "integrity": "sha512-5b97WpKMX+Y43YKi4zVcCVLtK5F98dFls3Oxui8LbnmRsseKenbbDinmvxrWegKDMmlkIq/XHuyy0UGLtpCDKg==",
+      "dependencies": {
+        "@typescript-eslint/types": "8.0.0",
+        "@typescript-eslint/visitor-keys": "8.0.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/utils": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.0.0.tgz",
+      "integrity": "sha512-k/oS/A/3QeGLRvOWCg6/9rATJL5rec7/5s1YmdS0ZU6LHveJyGFwBvLhSRBv6i9xaj7etmosp+l+ViN1I9Aj/Q==",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.0.0",
+        "@typescript-eslint/types": "8.0.0",
+        "@typescript-eslint/typescript-estree": "8.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.0.0.tgz",
+      "integrity": "sha512-oN0K4nkHuOyF3PVMyETbpP5zp6wfyOvm7tWhTMfoqxSSsPmJIh6JNASuZDlODE8eE+0EB9uar+6+vxr9DBTYOA==",
+      "dependencies": {
+        "@typescript-eslint/types": "8.0.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/@types/eslint": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
+      "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.11",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.11.tgz",
@@ -327,14 +675,12 @@
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@rushstack/eslint-patch": "1.10.4",
+    "@stylistic/eslint-plugin": "2.6.1",
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "eslint-plugin-import": "2.29.1",
     "eslint-plugin-jsdoc": "48.11.0",

--- a/src/eslint-config-standard-with-typescript.ts
+++ b/src/eslint-config-standard-with-typescript.ts
@@ -1,5 +1,6 @@
 /**
  * Adapted from eslint-config-standard-with-typescript v40.0.0, with some v44.0.0 sprinkled in.
+ * Stylistic rules replaced with @stylistic.
  *
  * eslint-config-standard-with-typescript is now called eslint-config-love, and is maintained by Shahar "Dawn" Or.
  * It is licensed under the MIT license. See: https://github.com/mightyiam/eslint-config-love/blob/main/LICENSE
@@ -9,32 +10,15 @@ import type { Linter } from 'eslint'
 import configStandard = require('./eslint-config-standard.js')
 
 const equivalents = [
-  'block-spacing',
-  'comma-spacing',
-  'dot-notation',
-  'brace-style',
-  'func-call-spacing',
-  'indent',
-  'key-spacing',
-  'keyword-spacing',
-  'lines-between-class-members',
   'no-array-constructor',
   'no-dupe-class-members',
-  'no-extra-parens',
   'no-implied-eval',
   'no-loss-of-precision',
   'no-redeclare',
-  'no-throw-literal',
   'no-unused-vars',
   'no-unused-expressions',
   'no-useless-constructor',
-  'object-curly-spacing',
-  'prefer-promise-reject-errors',
-  'quotes',
-  'semi',
-  'space-before-blocks',
-  'space-before-function-paren',
-  'space-infix-ops'
+  'prefer-promise-reject-errors'
 ] as const
 
 const ruleFromStandard = (name: string): Linter.RuleEntry => {
@@ -61,8 +45,6 @@ const config: Linter.Config = {
   parser: '@typescript-eslint/parser',
   rules: {
     ...configStandard.rules,
-
-    'comma-dangle': 'off',
 
     // TypeScript has this functionality by default:
     'no-undef': 'off',
@@ -94,65 +76,7 @@ const config: Linter.Config = {
       minimumDescriptionLength: 3
     }],
     '@typescript-eslint/ban-tslint-comment': 'error',
-    '@typescript-eslint/ban-types': ['error', {
-      extendDefaults: false,
-      types: {
-        String: {
-          message: 'Use string instead',
-          fixWith: 'string'
-        },
-        Boolean: {
-          message: 'Use boolean instead',
-          fixWith: 'boolean'
-        },
-        Number: {
-          message: 'Use number instead',
-          fixWith: 'number'
-        },
-        Symbol: {
-          message: 'Use symbol instead',
-          fixWith: 'symbol'
-        },
-        BigInt: {
-          message: 'Use bigint instead',
-          fixWith: 'bigint'
-        },
-        Function: {
-          message: [
-            'The `Function` type accepts any function-like value.',
-            'It provides no type safety when calling the function, which can be a common source of bugs.',
-            'It also accepts things like class declarations, which will throw at runtime as they will not be called with `new`.',
-            'If you are expecting the function to accept certain arguments, you should explicitly define the function shape.'
-          ].join('\n')
-        },
-        // object typing
-        Object: {
-          message: [
-            'The `Object` type actually means "any non-nullish value", so it is marginally better than `unknown`.',
-            '- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.',
-            '- If you want a type meaning "any value", you probably want `unknown` instead.'
-          ].join('\n')
-        },
-        '{}': {
-          message: [
-            '`{}` actually means "any non-nullish value".',
-            '- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.',
-            '- If you want a type meaning "any value", you probably want `unknown` instead.'
-          ].join('\n')
-        }
-      }
-    }],
     '@typescript-eslint/class-literal-property-style': ['error', 'fields'],
-    '@typescript-eslint/comma-dangle': ['error', {
-      arrays: 'never',
-      objects: 'never',
-      imports: 'never',
-      exports: 'never',
-      functions: 'never',
-      enums: 'ignore',
-      generics: 'ignore',
-      tuples: 'ignore'
-    }],
     '@typescript-eslint/consistent-generic-constructors': ['error', 'constructor'],
     '@typescript-eslint/consistent-indexed-object-style': ['error', 'record'],
     '@typescript-eslint/consistent-type-assertions': [
@@ -177,13 +101,6 @@ const config: Linter.Config = {
       allowTypedFunctionExpressions: true,
       allowDirectConstAssertionInArrowFunctions: true
     }],
-    '@typescript-eslint/member-delimiter-style': [
-      'error',
-      {
-        multiline: { delimiter: 'none' },
-        singleline: { delimiter: 'comma', requireLast: false }
-      }
-    ],
     '@typescript-eslint/method-signature-style': 'error',
     '@typescript-eslint/naming-convention': ['error', {
       selector: 'variableLike',
@@ -232,7 +149,6 @@ const config: Linter.Config = {
       allowAny: false
     }],
     '@typescript-eslint/triple-slash-reference': ['error', { lib: 'never', path: 'never', types: 'never' }],
-    '@typescript-eslint/type-annotation-spacing': 'error',
     '@typescript-eslint/unbound-method': ['error', { ignoreStatic: false }],
     'no-void': ['error', { allowAsStatement: true }]
   }

--- a/src/eslint-config-standard.ts
+++ b/src/eslint-config-standard.ts
@@ -1,11 +1,20 @@
 /**
- * Adapted from eslint-config-standard v17.1.0.
+ * Adapted from eslint-config-standard v17.1.0. Stylistic rules replaced with @stylistic.
  * See: https://github.com/standard/eslint-config-standard/blob/master/LICENSE
  *
  * eslint-config-standard. MIT License. Feross Aboukhadijeh <https://feross.org/opensource>
  */
 
 import { type Linter } from 'eslint'
+import stylistic = require('@stylistic/eslint-plugin')
+
+const customizedStylistic = stylistic.configs.customize({
+  braceStyle: '1tbs',
+  quoteProps: 'as-needed',
+  commaDangle: 'never',
+  arrowParens: true,
+  jsx: false
+})
 
 const config: Linter.Config = {
   parserOptions: {
@@ -19,7 +28,8 @@ const config: Linter.Config = {
   plugins: [
     'import',
     'n',
-    'promise'
+    'promise',
+    '@stylistic'
   ],
 
   globals: {
@@ -29,82 +39,29 @@ const config: Linter.Config = {
   },
 
   rules: {
+    ...customizedStylistic.rules,
+    '@stylistic/space-before-function-paren': ['error', 'always'],
+    '@stylistic/operator-linebreak': ['error', 'after', { overrides: { '?': 'before', ':': 'before', '|>': 'before' } }],
+
     'no-var': 'warn',
     'object-shorthand': ['warn', 'properties'],
 
     'accessor-pairs': ['error', { setWithoutGet: true, enforceForClassMembers: true }],
-    'array-bracket-spacing': ['error', 'never'],
     'array-callback-return': ['error', {
       allowImplicit: false,
       checkForEach: false
     }],
-    'arrow-spacing': ['error', { before: true, after: true }],
-    'block-spacing': ['error', 'always'],
-    'brace-style': ['error', '1tbs', { allowSingleLine: true }],
     camelcase: ['error', {
       allow: ['^UNSAFE_'],
       properties: 'never',
       ignoreGlobals: true
     }],
-    'comma-dangle': ['error', {
-      arrays: 'never',
-      objects: 'never',
-      imports: 'never',
-      exports: 'never',
-      functions: 'never'
-    }],
-    'comma-spacing': ['error', { before: false, after: true }],
-    'comma-style': ['error', 'last'],
-    'computed-property-spacing': ['error', 'never', { enforceForClassMembers: true }],
     'constructor-super': 'error',
     curly: ['error', 'multi-line'],
     'default-case-last': 'error',
-    'dot-location': ['error', 'property'],
     'dot-notation': ['error', { allowKeywords: true }],
-    'eol-last': 'error',
     eqeqeq: ['error', 'always', { null: 'ignore' }],
-    'func-call-spacing': ['error', 'never'],
-    'generator-star-spacing': ['error', { before: true, after: true }],
-    indent: ['error', 2, {
-      SwitchCase: 1,
-      VariableDeclarator: 1,
-      outerIIFEBody: 1,
-      MemberExpression: 1,
-      FunctionDeclaration: { parameters: 1, body: 1 },
-      FunctionExpression: { parameters: 1, body: 1 },
-      CallExpression: { arguments: 1 },
-      ArrayExpression: 1,
-      ObjectExpression: 1,
-      ImportDeclaration: 1,
-      flatTernaryExpressions: false,
-      ignoreComments: false,
-      ignoredNodes: [
-        'TemplateLiteral *',
-        'JSXElement',
-        'JSXElement > *',
-        'JSXAttribute',
-        'JSXIdentifier',
-        'JSXNamespacedName',
-        'JSXMemberExpression',
-        'JSXSpreadAttribute',
-        'JSXExpressionContainer',
-        'JSXOpeningElement',
-        'JSXClosingElement',
-        'JSXFragment',
-        'JSXOpeningFragment',
-        'JSXClosingFragment',
-        'JSXText',
-        'JSXEmptyExpression',
-        'JSXSpreadChild'
-      ],
-      offsetTernaryExpressions: true
-    }],
-    'key-spacing': ['error', { beforeColon: false, afterColon: true }],
-    'keyword-spacing': ['error', { before: true, after: true }],
-    'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
-    'multiline-ternary': ['error', 'always-multiline'],
     'new-cap': ['error', { newIsCap: true, capIsNew: false, properties: true }],
-    'new-parens': 'error',
     'no-array-constructor': 'error',
     'no-async-promise-executor': 'error',
     'no-caller': 'error',
@@ -130,9 +87,7 @@ const config: Linter.Config = {
     'no-extend-native': 'error',
     'no-extra-bind': 'error',
     'no-extra-boolean-cast': 'error',
-    'no-extra-parens': ['error', 'functions'],
     'no-fallthrough': 'error',
-    'no-floating-decimal': 'error',
     'no-func-assign': 'error',
     'no-global-assign': 'error',
     'no-implied-eval': 'error',
@@ -146,18 +101,7 @@ const config: Linter.Config = {
     'no-misleading-character-class': 'error',
     'no-prototype-builtins': 'error',
     'no-useless-catch': 'error',
-    'no-mixed-operators': ['error', {
-      groups: [
-        ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
-        ['&&', '||'],
-        ['in', 'instanceof']
-      ],
-      allowSamePrecedence: true
-    }],
-    'no-mixed-spaces-and-tabs': 'error',
-    'no-multi-spaces': 'error',
     'no-multi-str': 'error',
-    'no-multiple-empty-lines': ['error', { max: 1, maxBOF: 0, maxEOF: 0 }],
     'no-new': 'error',
     'no-new-func': 'error',
     'no-new-object': 'error',
@@ -175,11 +119,8 @@ const config: Linter.Config = {
     'no-sequences': 'error',
     'no-shadow-restricted-names': 'error',
     'no-sparse-arrays': 'error',
-    'no-tabs': 'error',
     'no-template-curly-in-string': 'error',
     'no-this-before-super': 'error',
-    'no-throw-literal': 'error',
-    'no-trailing-spaces': 'error',
     'no-undef': 'error',
     'no-undef-init': 'error',
     'no-unexpected-multiline': 'error',
@@ -208,34 +149,12 @@ const config: Linter.Config = {
     'no-useless-rename': 'error',
     'no-useless-return': 'error',
     'no-void': 'error',
-    'no-whitespace-before-property': 'error',
     'no-with': 'error',
-    'object-curly-newline': ['error', { multiline: true, consistent: true }],
-    'object-curly-spacing': ['error', 'always'],
-    'object-property-newline': ['error', { allowMultiplePropertiesPerLine: true }],
     'one-var': ['error', { initialized: 'never' }],
-    'operator-linebreak': ['error', 'after', { overrides: { '?': 'before', ':': 'before', '|>': 'before' } }],
-    'padded-blocks': ['error', { blocks: 'never', switches: 'never', classes: 'never' }],
     'prefer-const': ['error', { destructuring: 'all' }],
     'prefer-promise-reject-errors': 'error',
     'prefer-regex-literals': ['error', { disallowRedundantWrapping: true }],
-    'quote-props': ['error', 'as-needed'],
-    quotes: ['error', 'single', { avoidEscape: true, allowTemplateLiterals: false }],
-    'rest-spread-spacing': ['error', 'never'],
-    semi: ['error', 'never'],
-    'semi-spacing': ['error', { before: false, after: true }],
-    'space-before-blocks': ['error', 'always'],
-    'space-before-function-paren': ['error', 'always'],
-    'space-in-parens': ['error', 'never'],
-    'space-infix-ops': 'error',
-    'space-unary-ops': ['error', { words: true, nonwords: false }],
-    'spaced-comment': ['error', 'always', {
-      line: { markers: ['*package', '!', '/', ',', '='] },
-      block: { balanced: true, markers: ['*package', '!', ',', ':', '::', 'flow-include'], exceptions: ['*'] }
-    }],
     'symbol-description': 'error',
-    'template-curly-spacing': ['error', 'never'],
-    'template-tag-spacing': ['error', 'never'],
     'unicode-bom': ['error', 'never'],
     'use-isnan': ['error', {
       enforceForSwitchCase: true,
@@ -243,7 +162,6 @@ const config: Linter.Config = {
     }],
     'valid-typeof': ['error', { requireStringLiterals: true }],
     'wrap-iife': ['error', 'any', { functionPrototypeMethods: true }],
-    'yield-star-spacing': ['error', 'both'],
     yoda: ['error', 'never'],
 
     'import/export': 'error',

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,16 +62,6 @@ export = {
             ignoreArrowShorthand: true,
             ignoreVoidOperator: false
           }
-        ],
-        // Un-ban the {} type, which is the only concise way to express "any non-nullish value"
-        '@typescript-eslint/ban-types': [
-          'error',
-          {
-            extendDefaults: true,
-            types: {
-              '{}': false
-            }
-          }
         ]
       }
     },


### PR DESCRIPTION
Future versions of ESLint are dropping style-related rules, focusing solely on functional rules. typescript-eslint v8 is already dropping TypeScript-related style rules. By migrating to `@stylistic`, we retain similar behavior for both JS and TS.

Prerequisite for #203 and ESLint v9 support.

BREAKING CHANGE: Some rules have changed and new errors are possible.